### PR TITLE
调整 启动参数（支持 指定端口、样式、启动目录）、完成生成静态、Vercel发布功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules/
 package-lock.json
 .DS_Store
+.spress

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 package-lock.json
 .DS_Store
 .spress
+.vercel
+dist

--- a/bin/build.js
+++ b/bin/build.js
@@ -67,12 +67,14 @@ module.exports = async function (options = {
     `输出目录: ${options.output}`
   ].join('\n  '))
 
-
   // 分析源码
   provider.resolvePath = filePath => path.resolve(options.root, filePath)
   provider.distPath = filePath => path.resolve(options.output, filePath)
   provider.assetsPath = filePath => path.resolve(__dirname, '../src/', filePath)
   await provider.patch(await getFolder(options.root))
+
+  // 如果不存在输出目录，则创建
+  !fs.existsSync(options.output) && fs.mkdirSync(options.output)
 
   // 复制 asssets 文件
   console.log('文件复制：')

--- a/bin/build.js
+++ b/bin/build.js
@@ -12,8 +12,10 @@ const makeFiles = async (provider, options) => {
     const node = provider.nodes[nodeName]
     if (node.isFileNode) {
       // 文件节点
-      files.push(node.path)
+      delete provider.nodes[node.path]
       node.path = node.path.replace('README.', 'index.').replace('.md', '.html')
+      provider.nodes[node.path] = node
+      files.push(node.path)
     } else {
       // 目录节点，依次创建目录结构
       const folderPath = provider.distPath(node.path)

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,0 +1,62 @@
+const path = require('path')
+const ssr = require('../src/ssr')
+const fs = require('fs')
+const { getFolder } = require('../src/menu')
+const provider = require('../src/markdown')
+
+const makeFiles = async (provider, options) => {
+
+  // 获取所有源码文件
+  const files = []
+  Object.keys(provider.nodes).forEach(nodeName => {
+    const node = provider.nodes[nodeName]
+    if (node.isFileNode) {
+      // 文件节点
+      files.push(node.path)
+      node.path = node.path.replace('README.', 'index.').replace('.md', '.html')
+    } else {
+      // 目录节点，依次创建目录结构
+      const folderPath = provider.distPath(node.path)
+      !fs.existsSync(folderPath) && fs.mkdirSync(folderPath)
+    }
+  })
+
+  // 根据文件记录，依次生成静态
+  let reqFile = files.shift()
+  while (reqFile) {
+    const body = await ssr.renderMarkdown({
+      reqFile,
+      provider,
+      template: ssr.template,
+      options
+    })
+    fs.writeFileSync(provider.distPath(reqFile), body, {
+      encoding: 'utf-8'
+    })
+    reqFile = files.shift()
+  }
+}
+
+module.exports = async function (options = {
+  theme: 'default',
+  root: path.resolve('.'),
+  output: path.resolve('dist')
+}) {
+
+  console.log(`编译静态文件
+源码目录: ${options.root}
+输出目录: ${options.output}`)
+
+
+  // 分析源码
+  provider.resolvePath = filePath => path.resolve(options.root, './' + filePath)
+  provider.distPath = filePath => path.resolve(options.output, './' + filePath)
+  await provider.patch(await getFolder(options.root))
+
+  // todo 复制 asssets 文件
+
+  // 生成静态
+  await makeFiles(provider, options)
+
+  console.log('生成完毕')
+}

--- a/bin/build.js
+++ b/bin/build.js
@@ -48,9 +48,9 @@ const copyAssets = (sourcePath, { assetsPath, distPath }) => {
     if (fs.lstatSync(assetsPath(relativePath)).isDirectory()) {
       copyAssets(relativePath, provider) // 如果是目录，则继续遍历
     } else {
+      // 复制资源文件
       console.log(`  ${relativePath}`)
-      fs.createReadStream(assetsPath(relativePath))
-        .pipe(fs.createWriteStream(distPath(relativePath)))
+      fs.copyFileSync(assetsPath(relativePath), distPath(relativePath))
     }
   })
 }
@@ -78,7 +78,7 @@ module.exports = async function (options = {
 
   // 复制 asssets 文件
   console.log('文件复制：')
-  copyAssets('assets', provider)
+  await copyAssets('assets', provider)
 
   // 生成静态
   console.log('生成静态：')

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,7 +13,10 @@ const chalkAnimation = require('chalk-animation');
 program
     .command('start')
     .description('启动本地开发环境')
-    .action(async () => {
+    .usage('[options] root-path')
+    .option('-t, --theme [theme]', 'Markdown样式，可选 default、techo')
+    .option('-p, --port [port]', '监听端口')
+    .action(async (options) => {
         clear()
         console.log('')
         console.log('')
@@ -23,13 +26,14 @@ program
 
         // 启动开发服务器
         startDev({
-            root: path.resolve('.')
+            theme: options.theme || 'default',
+            port: options.port || 3000,
+            root: path.resolve(options.args.length > 0 ? options.args[0] : '.')
         })
 
         // 打开浏览器
         open(`http://localhost:3000`);
     })
-
 
 program
     .command('build')
@@ -37,6 +41,7 @@ program
     .action(async () => {
         console.log('编译静态文件')
     })
+
 program
     .command('publish')
     .description('发布文件到服务器')

--- a/bin/index.js
+++ b/bin/index.js
@@ -2,12 +2,14 @@
 const program = require('commander')
 program.version(require('../package').version)
 const path = require('path')
+const fs = require('fs')
 const { promisify } = require('util')
 const figlet = promisify(require('figlet'))
 const clear = require('clear')
 const { startDev } = require('../src/index')
 const open = require("open")
 const chalkAnimation = require('chalk-animation');
+const { fstat } = require('fs')
 
 
 program
@@ -39,7 +41,17 @@ program
     .command('build')
     .description('编译页面文件(生成html)')
     .action(async () => {
+        clear()
+        console.log('')
         console.log('编译静态文件')
+
+        !fs.existsSync(path.resolve('.spress')) && fs.mkdirSync(path.resolve('.spress'))
+        !fs.existsSync(path.resolve('.spress/dist')) && fs.mkdirSync(path.resolve('.spress/dist'))
+        fs.writeFileSync(path.resolve('.spress/dist/index.html'), "<h1>Smart Press</h1>", {
+            encoding: 'utf-8'
+        })
+
+        process.exit()
     })
 
 program

--- a/bin/index.js
+++ b/bin/index.js
@@ -2,15 +2,13 @@
 const program = require('commander')
 program.version(require('../package').version)
 const path = require('path')
-const fs = require('fs')
 const { promisify } = require('util')
 const figlet = promisify(require('figlet'))
 const clear = require('clear')
 const { startDev } = require('../src/index')
 const open = require("open")
-const chalkAnimation = require('chalk-animation');
-const { fstat } = require('fs')
-
+const chalkAnimation = require('chalk-animation')
+const build = require('./build')
 
 program
     .command('start')
@@ -40,17 +38,16 @@ program
 program
     .command('build')
     .description('编译页面文件(生成html)')
+    .option('-t, --theme [theme]', 'Markdown样式，可选 default、techo')
     .option('-o, --output [output]', '输出目录')
     .action(async (options) => {
-        clear()
         console.log('')
 
-        const output = options.output || 'dist'
-        console.log(`编译静态文件，输出目录: ${output}`)
-
-        !fs.existsSync(path.resolve(output)) && fs.mkdirSync(path.resolve(output))
-        fs.writeFileSync(path.resolve(`${output}/index.html`), "<h1>Smart Press</h1>", {
-            encoding: 'utf-8'
+        // 生成静态
+        await build({
+            theme: options.theme || 'default',
+            root: path.resolve(options.args.length > 0 ? options.args[0] : '.'),
+            output: path.resolve(options.output || 'dist')
         })
 
         process.exit()

--- a/bin/index.js
+++ b/bin/index.js
@@ -40,14 +40,16 @@ program
 program
     .command('build')
     .description('编译页面文件(生成html)')
-    .action(async () => {
+    .option('-o, --output [output]', '输出目录')
+    .action(async (options) => {
         clear()
         console.log('')
-        console.log('编译静态文件')
 
-        !fs.existsSync(path.resolve('.spress')) && fs.mkdirSync(path.resolve('.spress'))
-        !fs.existsSync(path.resolve('.spress/dist')) && fs.mkdirSync(path.resolve('.spress/dist'))
-        fs.writeFileSync(path.resolve('.spress/dist/index.html'), "<h1>Smart Press</h1>", {
+        const output = options.output || 'dist'
+        console.log(`编译静态文件，输出目录: ${output}`)
+
+        !fs.existsSync(path.resolve(output)) && fs.mkdirSync(path.resolve(output))
+        fs.writeFileSync(path.resolve(`${output}/index.html`), "<h1>Smart Press</h1>", {
             encoding: 'utf-8'
         })
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "spress": "./bin/index.js"
   },
   "scripts": {
-    "start": "node index.js",
+    "start": "node bin/index.js start demo",
+    "install": "npm link",
     "dev": "nodemon index.js"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "start": "node bin/index.js start demo",
-    "install": "npm link",
     "dev": "nodemon index.js"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node bin/index.js start demo",
+    "build": "node bin/index.js build demo",
     "dev": "nodemon index.js"
   },
   "keywords": [],

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,21 @@
 const { createServer } = require('./devserver')
-const { tranHtml } = require('./markdown')
 const { createMiddleware } = require('./menu')
 const path = require('path')
 const ssr = require('./ssr')
-const app = createServer()
 const fs = require('fs')
 const provider = require('./markdown')
 
 const KoaStatic = require('koa-static')
 
 module.exports.startDev = (options = {
+    theme: 'default',
     root: path.resolve('.'),
     port: 3000
 }) => {
+
+    const app = createServer({
+        watchFolder: options.root
+    })
 
     // 获取文件目录
     provider.resolvePath = filePath => path.resolve(options.root, './' + filePath)
@@ -50,7 +53,7 @@ module.exports.startDev = (options = {
         await provider.patch(ctx.menu)
 
         const { request: { url, query } } = ctx
-        const skin = query.skin || '默认皮肤'
+        const skin = options.theme || '默认皮肤'
         const reqPath = url.split('?')[0]
         const reqFile = path.extname(reqPath) === '' ? reqPath + '/README.md' : reqPath
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,34 +53,16 @@ module.exports.startDev = (options = {
         await provider.patch(ctx.menu)
 
         const { request: { url, query } } = ctx
-        const skin = options.theme || '默认皮肤'
         const reqPath = url.split('?')[0]
         const reqFile = path.extname(reqPath) === '' ? reqPath + '/README.md' : reqPath
 
-        const data = {
-            menu: provider.toArray(fileNode => ({
-                path: fileNode.path,
-                name: fileNode.title,
-                prefix: fileNode.prefix || ''
-            })),
-            breadcrumb: null, //面包屑导航
-            catalogs: [], //目录
-            markdown: '' //正文
-        }
-        await provider.getItem(reqFile, fileNode => {
-            if (!fileNode) {
-                data.markdown = `<h1>文件不存在: ${reqFile}</h1>`
-            } else {
-                // 面包屑也可以通过 fileNode.breadcrumb.toHtml(treeNode, indexFileNode) 方式获取更加复杂的样式
-                data.breadcrumb = fileNode.breadcrumb.html
-                data.catalogs = fileNode.catalogs
-                data.markdown = [
-                    fileNode.html, // 解析后的 html
-                    fileNode.getTheme(skin).html  // 样式代码
-                ].join('')
-            }
-        });
-        ctx.body = await ssr.createRender(path.resolve(__dirname, './template/App.vue'))(data)
+        ctx.body = await ssr.renderMarkdown({
+            reqFile,
+            provider,
+            template: ssr.template,
+            options
+        })
+
         await next()
     })
 

--- a/src/markdown/breadcrumb/index.js
+++ b/src/markdown/breadcrumb/index.js
@@ -1,5 +1,10 @@
 // 计算面包屑
 
+const indexFiles = [
+  'README.md',
+  'index.html'
+]
+
 module.exports = async ({ fileNode }, next) => {
   const breadcrumb = fileNode.breadcrumb = {
     nodes: [fileNode], //父子关系，
@@ -29,7 +34,7 @@ function toHtml(formatNode, separator) {
         treeNode, // 其他节点 为 treeNode 节点
       treeNode.isFileNode ?
         treeNode : // 如果节点是 fileNode，直接传入
-        treeNode.children.length > 0 && treeNode.getFileName(treeNode.children[0]) == 'README.md' ?
+        treeNode.children.length > 0 && indexFiles.indexOf(treeNode.getFileName(treeNode.children[0])) != -1 ?
           treeNode.children[0] : // 如果 当前 treeNode 节点存在子节点，并且第一个为 README.md，传入
           null
     )
@@ -41,7 +46,11 @@ function formatDefault(treeNode, indexFileNode) {
   let itemHtml = ''
   if (indexFileNode) {
     // treeNode存在 首页( README.md)，显示链接
-    itemHtml = `<a href="/${indexFileNode.path.replace('README.md', '')}">${indexFileNode.title || indexFileNode.path}</a>`
+    let path = indexFileNode.path
+    indexFiles.forEach(item=>{
+      path = path.replace(item, '')
+    })
+    itemHtml = `<a href="/${path}">${indexFileNode.title || indexFileNode.path}</a>`
   } else {
     // treeNode 无首页，只显示 路径文本
     itemHtml = treeNode.path

--- a/src/markdown/marked/index.js
+++ b/src/markdown/marked/index.js
@@ -4,8 +4,7 @@ let indexData = {}
 
 // Markdown 转 HTML
 module.exports = async ({ fileNode }, next) => {
-  await next()
-
+  
   // 菜单处理
   if (fileNode.catalogs instanceof Array) {
     catelogs = {}
@@ -14,6 +13,8 @@ module.exports = async ({ fileNode }, next) => {
 
   // HTML处理
   fileNode.html = marked(fileNode.body)
+
+  await next()
 }
 
 function setCatelogs(catelogs) {

--- a/src/ssr/index.js
+++ b/src/ssr/index.js
@@ -3,18 +3,51 @@ const serverRenderer = require('@vue/server-renderer')
 const compilerSsr = require('@vue/compiler-ssr')
 const compilerSfc = require('@vue/compiler-sfc')
 const fs = require('fs')
+const path = require('path')
 
-module.exports.createRender = path => {
+const createRender = path => {
     const { descriptor } = compilerSfc.parse(fs.readFileSync(path, 'utf-8'))
     const render = compilerSsr.compile(descriptor.template.content).code
-    
-    return async (data)  => {
+
+    return async (data) => {
         const app = Vue.createApp({
-            ssrRender: new Function('require',render)(require), // 写法二
+            ssrRender: new Function('require', render)(require), // 写法二
             data: () => data
         })
         return serverRenderer.renderToString(app)
     }
 }
 
+const renderMarkdown = async ({ reqFile, template, provider, options }) => {
+    const skin = options.theme || '默认皮肤'
+    const data = {
+        menu: provider.toArray(fileNode => ({
+            path: fileNode.path,
+            name: fileNode.title,
+            prefix: fileNode.prefix || ''
+        })),
+        breadcrumb: null, //面包屑导航
+        catalogs: [], //目录
+        markdown: '' //正文
+    }
+    await provider.getItem(reqFile, fileNode => {
+        if (!fileNode) {
+            data.markdown = `<h1>文件不存在: ${reqFile}</h1>`
+        } else {
+            // 面包屑也可以通过 fileNode.breadcrumb.toHtml(treeNode, indexFileNode) 方式获取更加复杂的样式
+            data.breadcrumb = fileNode.breadcrumb.html
+            data.catalogs = fileNode.catalogs
+            data.markdown = [
+                fileNode.html, // 解析后的 html
+                fileNode.getTheme(skin).html  // 样式代码
+            ].join('')
+        }
+    });
+    return await createRender(template)(data)
+}
 
+module.exports = {
+    createRender,
+    renderMarkdown,
+    template: path.resolve(__dirname, '../template/App.vue')
+}


### PR DESCRIPTION
可以通过 npm link 安装到系统，这样就可以在任意目录执行（不安装 可以使用 node bin/index.js）。

## 已完成工作

### 1. 命令参数调整

现在支持的命令
```bash
>spress -h
Usage: index [options] [command]

Options:
  -V, --version    output the version number
  -h, --help       display help for command

Commands:
  start [options]  启动本地开发环境
  build [options]  编译页面文件(生成html)
  publish          发布文件到服务器
  help [command]   display help for command
```

启动参数：
```bash
>spress start -h
Usage: index start [options] root-path

启动本地开发环境

Options:
  -t, --theme [theme]  Markdown样式，可选 default、techo
  -p, --port [port]    监听端口
  -h, --help           display help for command
```

生成静态参数：
```bash
>spress build -h
Usage: index build [options]

编译页面文件(生成html)

Options:
  -t, --theme [theme]    Markdown样式，可选 default、techo
  -o, --output [output]  输出目录
  -h, --help             display help for command
```

### 2. vercel发布
git pull 或者 发起pr 时，自动执行 yarn build 生成静态并发布到 vercel

Vercel发布演示：https://smarty-press.mqycn.vercel.app/

PR提交效果：https://github.com/mqycn/smarty-press/pull/6 https://github.com/mqycn/smarty-press/pull/8

## 进度
- [X] spress run 增加到启动参数
- [x] spress build 生成静态 https://github.com/su37josephxia/smarty-press/issues/7
- [x] github提交自动发布到Vercel https://github.com/su37josephxia/smarty-press/issues/2
- [ ] 移动端遮挡问题




