### PR TITLE
修复浏览器在768~991的宽度尺寸下,左侧目录和底部目录工具同时不显示的bug

### DIFF
--- a/src/assets/responsive.css
+++ b/src/assets/responsive.css
@@ -4,7 +4,7 @@
     display: none;
   }
 }
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 992px) {
   .markdown-catalogs {
     position: fixed;
     right: 10px;
@@ -32,7 +32,7 @@
   }
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 992px) {
   .markdown-catalogs {
     right: 10px;
     background: #FFF;


### PR DESCRIPTION
![min-size](https://user-images.githubusercontent.com/23348287/133719074-3b5ef6cb-6f30-47eb-92de-1f93436b41fd.png)
![max-size](https://user-images.githubusercontent.com/23348287/133719088-95c26295-c7c8-4f21-8461-d6327ff21073.png)

如上图所示，在浏览器的以上宽度尺寸的情况下，页面上没有显示左侧目录，底部的菜单工具栏也没有显示
（不好意思， 忘记关闭背景透明了，所以截图看起来有点怪异）
